### PR TITLE
Fixes an error when selecting a template

### DIFF
--- a/modules/embedinhtml.py
+++ b/modules/embedinhtml.py
@@ -167,7 +167,7 @@ def run_embedInHtml(key, fileName, outFileName, template_name):
         templatesource = ""
 
         if not template_name:
-            htmltemplate = input("\n\033[1;34m[*]\033[0;0m Use a custom (1) or predefined (2) template?\n").lower()
+            htmltemplate = input("\n\033[1;34m[*]\033[0;0m Use a custom (1) or predefined (2) template?\n")
             while True:
                 try:
                     htmltemplate = int(htmltemplate)


### PR DESCRIPTION
Hey,

There was an error while running the tool in interactive mode, when you have to select a template:


> [*] Use a custom (1) or predefined (2) template
> 2
> Traceback (most recent call last):
>   File "SharpShooter.py", line 615, in <module>
>     ss.run(args)
>   File "SharpShooter.py", line 609, in run
>     embedinhtml.run_embedInHtml(key, "./output/" + outputfile_payload, "./output/" + outputfile + ".html", template)
>   File "/home/username/SharpShooter/modules/embedinhtml.py", line 170, in run_embedInHtml
>     htmltemplate = input("\n\033[1;34m[*]\033[0;0m Use a custom (1) or predefined (2) template?\n").lower()
> AttributeError: 'int' object has no attribute 'lower'

It comes from this commit: https://github.com/mdsecactivebreach/SharpShooter/commit/d17a4b732ee755326a316caac98a550ad177036f#diff-de99cffbd7d8d4b605fb8de4adb74c43 where things where converted to Python2/3, especially the function `raw_input` to `input`.


Great tool by the way!


Cheers!