### PR TITLE
Fix SetVersion function in stagelessv4.vba

### DIFF
--- a/templates/stagelessv4.vba
+++ b/templates/stagelessv4.vba
@@ -4,6 +4,7 @@ End Sub
 Sub SetVersion
 Dim shell
 Set shell = CreateObject("WScript.Shell")
+shell.Environment("Process").Item("COMPLUS_Version") = "v4.0.30319"
 End Sub
 
 Private Function decodeHex(hex)


### PR DESCRIPTION
SetVersion function in stagelessv4.vba template was missing the line to actually set the COMPLUS_Version variable, causing the .NET 3.5 installation prompt on a fresh Windows 10 installation when using a stageless payload.